### PR TITLE
Don't set codegpt_openai_api_key to nil if env returns nil

### DIFF
--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -1,4 +1,6 @@
-vim.g["codegpt_openai_api_key"] = os.getenv("OPENAI_API_KEY")
+if os.getenv("OPENAI_API_KEY") ~= nil then
+    vim.g["codegpt_openai_api_key"] = os.getenv("OPENAI_API_KEY")
+end
 vim.g["codegpt_chat_completions_url"] = "https://api.openai.com/v1/chat/completions"
 
 -- clears visual selection after completion


### PR DESCRIPTION
vim.g["codegpt_openai_api_key"] = "key..." https://github.com/dpayne/CodeGPT.nvim/issues/9#issuecomment-1464188586 doesn't work for me with neovim 0.7.2 on windows 11 without this change.