### PR TITLE
Feat: Include Azure as an additional service provider option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ vim.g["codegpt_commands"] = {
 -- Open API key and api endpoint
 vim.g["codegpt_openai_api_key"] = os.getenv("OPENAI_API_KEY")
 vim.g["codegpt_chat_completions_url"] = "https://api.openai.com/v1/chat/completions"
+vim.g["codegpt_openai_api_provider"] = "OpenAI" -- or Azure
 
 -- clears visual selection after completion
 vim.g["codegpt_clear_visual_selection"] = true

--- a/lua/codegpt/commands.lua
+++ b/lua/codegpt/commands.lua
@@ -1,38 +1,8 @@
 local OpenAiApi = require("codegpt.openai_api")
 local CommandsList = require("codegpt.commands_list")
-local Render = require("codegpt.template_render")
+local Providers = require("codegpt.providers")
 
 local Commands = {}
-
-local function generate_messages(command, cmd_opts, command_args, text_selection)
-  local system_message = Render.render(command, cmd_opts.system_message_template, command_args, text_selection)
-  local user_message = Render.render(command, cmd_opts.user_message_template, command_args, text_selection)
-
-  local messages = {}
-  if system_message ~= nil and system_message ~= "" then
-    table.insert(messages, {role = "system", content = system_message})
-  end
-
-  if user_message ~= nil and user_message ~= "" then
-    table.insert(messages, {role = "user", content = user_message})
-  end
-
-  return messages
-end
-
-local function get_max_tokens(max_tokens, messages)
-  local total_length = 0
-  for _, message in ipairs(messages) do
-    total_length = total_length + string.len(message.content)
-    total_length = total_length + string.len(message.role)
-  end
-
-  if total_length >= max_tokens then
-      error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_tokens)
-  end
-
-  return max_tokens - total_length
-end
 
 function Commands.run_cmd(command, command_args, text_selection)
   local cmd_opts = CommandsList.get_cmd_opts(command)
@@ -40,15 +10,7 @@ function Commands.run_cmd(command, command_args, text_selection)
       error("Command not found: " .. command)
   end
 
-  local messages = generate_messages(command, cmd_opts, command_args, text_selection)
-
-  local request = {
-    max_tokens = get_max_tokens(cmd_opts.max_tokens, messages),
-    temperature = cmd_opts.temperature,
-    n = cmd_opts.number_of_choices,
-    model = cmd_opts.model,
-    messages = messages,
-  }
+  local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)
 
   OpenAiApi.make_call(request, cmd_opts.callback)
 end

--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -3,6 +3,9 @@ if os.getenv("OPENAI_API_KEY") ~= nil then
 end
 vim.g["codegpt_chat_completions_url"] = "https://api.openai.com/v1/chat/completions"
 
+-- alternative provider
+vim.g["codegpt_openai_api_provider"] = "OpenAI"
+
 -- clears visual selection after completion
 vim.g["codegpt_clear_visual_selection"] = true
 

--- a/lua/codegpt/openai_api.lua
+++ b/lua/codegpt/openai_api.lua
@@ -1,66 +1,6 @@
 local curl = require("plenary.curl")
+local Providers = require("codegpt.providers")
 local OpenAIApi = {}
-
-local function get_code_block(lines2)
-    local code_block = {}
-    local in_code_block = false
-    for _, line in ipairs(lines2) do
-        if line:match("^```") then
-            in_code_block = not in_code_block
-        elseif in_code_block then
-            table.insert(code_block, line)
-        end
-    end
-    return code_block
-end
-
-local function contains_code_block(lines2)
-    for _, line in ipairs(lines2) do
-        if line:match("^```") then
-            return true
-        end
-    end
-    return false
-end
-
-local function parse_lines(response_text)
-  if vim.g["codegpt_write_response_to_err_log"] then
-    vim.api.nvim_err_write("ChatGPT response: \n" .. response_text .. "\n")
-  end
-
-  local lines = vim.fn.split(response_text, "\n")
-  if contains_code_block(lines) then
-    return get_code_block(lines)
-  end
-
-  return lines
-end
-
-local function handle_response(json, cb)
-  if json == nil then
-    print("Response empty")
-  elseif json.error then
-    print("Error: " .. json.error.message)
-  elseif not json.choices or 0 == #json.choices or not json.choices[1].message then
-    print("Error: " .. vim.fn.json_encode(json))
-  else
-    local response_text = json.choices[1].message.content
-    if response_text ~= nil then
-      if type(response_text) ~= "string" or response_text == "" then
-        print("Error: No response text " .. type(response_text))
-      else
-        local bufnr = vim.api.nvim_get_current_buf()
-        cb(parse_lines(response_text))
-        if vim.g["codegpt_clear_visual_selection"] then
-            vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
-            vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
-        end
-      end
-    else
-      print("Error: No message")
-    end
-  end
-end
 
 local function curl_callback(response, cb)
   local status = response.status
@@ -77,24 +17,18 @@ local function curl_callback(response, cb)
   end
   vim.schedule_wrap(function(msg)
     local json = vim.fn.json_decode(msg)
-    handle_response(json, cb)
+    Providers.get_provider().handle_response(json, cb)
   end)(body)
 end
 
 function OpenAIApi.make_call(payload, cb)
-  local token = vim.g["codegpt_openai_api_key"]
-  if not token then
-    error("OpenAIApi Key not found, set in vim with 'codegpt_openai_api_key' or as the env variable 'OPENAI_API_KEY'")
-  end
-
   local payload_str = vim.fn.json_encode(payload)
   local url = vim.g["codegpt_chat_completions_url"]
+  local headers = Providers.get_provider().make_headers()
+
   curl.post(url, {
     body = payload_str,
-    headers = {
-      Content_Type = "application/json",
-      Authorization = "Bearer " .. token,
-    },
+    headers = headers,
     callback = function(response)
       curl_callback(response, cb)
     end,

--- a/lua/codegpt/providers.lua
+++ b/lua/codegpt/providers.lua
@@ -1,0 +1,17 @@
+local OpenAIProvider = require("codegpt.providers.openai")
+local AzureProvider = require("codegpt.providers.azure")
+
+Providers = {}
+
+function Providers.get_provider()
+  local provider = vim.fn.tolower(vim.g["codegpt_openai_api_provider"])
+  if provider == "openai" then
+    return OpenAIProvider
+  elseif provider == "azure" then
+    return AzureProvider
+  else
+    error("Provider not found: " .. provider)
+  end
+end
+
+return Providers

--- a/lua/codegpt/providers/azure.lua
+++ b/lua/codegpt/providers/azure.lua
@@ -1,0 +1,86 @@
+local Render = require("codegpt.template_render")
+local Utils = require("codegpt.utils")
+
+AzureProvider = {}
+
+local function generate_messages(command, cmd_opts, command_args, text_selection)
+  local system_message = Render.render(command, cmd_opts.system_message_template, command_args, text_selection)
+  local user_message = Render.render(command, cmd_opts.user_message_template, command_args, text_selection)
+
+  local prompt = ""
+  if system_message ~= nil and system_message ~= "" then
+      prompt = "<|im_start|>" .. prompt .. "system\n" .. system_message .. "\n<|im_end|>\n"
+  end
+  
+  if user_message ~= nil and user_message ~= "" then
+      prompt = prompt .. "<|im_start|>user\n" .. user_message .. "\n<|im_end|>\n<|im_start|>assistant\n"
+  end
+  
+  return prompt
+end
+
+local function get_max_tokens(max_tokens, messages)
+  local total_length = string.len(messages)
+
+  if total_length >= max_tokens then
+      error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_tokens)
+  end
+
+  return max_tokens - total_length
+end
+
+
+
+function AzureProvider.make_request(command, cmd_opts, command_args, text_selection)
+  local messages = generate_messages(command, cmd_opts, command_args, text_selection)
+  local max_tokens = get_max_tokens(cmd_opts.max_tokens, messages)
+
+  local request = {
+    temperature = cmd_opts.temperature,
+    n = cmd_opts.number_of_choices,
+    model = cmd_opts.model,
+    prompt = messages,
+    max_tokens = max_tokens,
+    stop = "<|im_end|>",
+  }
+
+  return request
+end
+
+function AzureProvider.make_headers()
+  local token = vim.g["codegpt_openai_api_key"]
+  if not token then
+    error("OpenAIApi Key not found, set in vim with 'codegpt_openai_api_key' or as the env variable 'OPENAI_API_KEY'")
+  end
+
+  return { Content_Type = "application/json", ["api-key"] = token }
+end
+
+function AzureProvider.handle_response(json, cb)
+  if json == nil then
+    print("Response empty")
+  elseif json.error then
+    print("Error: " .. json.error.message)
+  elseif not json.choices or 0 == #json.choices or not json.choices[1].text then
+    print("Error: " .. vim.fn.json_encode(json))
+  else
+    local response_text = json.choices[1].text
+
+    if response_text ~= nil then
+      if type(response_text) ~= "string" or response_text == "" then
+        print("Error: No response text " .. type(response_text))
+      else
+        local bufnr = vim.api.nvim_get_current_buf()
+        cb(Utils.parse_lines(response_text))
+        if vim.g["codegpt_clear_visual_selection"] then
+            vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
+            vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
+        end
+      end
+    else
+      print("Error: No message")
+    end
+  end
+end
+
+return AzureProvider

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -1,0 +1,90 @@
+local Render = require("codegpt.template_render")
+local Utils = require("codegpt.utils")
+
+OpenAIProvider = {}
+
+local function generate_messages(command, cmd_opts, command_args, text_selection)
+  local system_message = Render.render(command, cmd_opts.system_message_template, command_args, text_selection)
+  local user_message = Render.render(command, cmd_opts.user_message_template, command_args, text_selection)
+
+  local messages = {}
+  if system_message ~= nil and system_message ~= "" then
+    table.insert(messages, {role = "system", content = system_message})
+  end
+
+  if user_message ~= nil and user_message ~= "" then
+    table.insert(messages, {role = "user", content = user_message})
+  end
+
+  return messages
+end
+
+local function get_max_tokens(max_tokens, messages)
+  local total_length = 0
+
+  for _, message in ipairs(messages) do
+    total_length = total_length + string.len(message.content)
+    total_length = total_length + string.len(message.role)
+  end
+
+  if total_length >= max_tokens then
+      error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_tokens)
+  end
+
+  return max_tokens - total_length
+end
+
+
+
+function OpenAIProvider.make_request(command, cmd_opts, command_args, text_selection)
+  local messages = generate_messages(command, cmd_opts, command_args, text_selection)
+  local max_tokens = get_max_tokens(cmd_opts.max_tokens, messages)
+
+  local request = {
+    temperature = cmd_opts.temperature,
+    n = cmd_opts.number_of_choices,
+    model = cmd_opts.model,
+    messages = messages,
+    max_tokens = max_tokens,
+  }
+
+  return request
+end
+
+function OpenAIProvider.make_headers()
+  local token = vim.g["codegpt_openai_api_key"]
+  if not token then
+    error("OpenAIApi Key not found, set in vim with 'codegpt_openai_api_key' or as the env variable 'OPENAI_API_KEY'")
+  end
+
+  return { Content_Type = "application/json", Authorization = "Bearer " .. token }
+end
+
+function OpenAIProvider.handle_response(json, cb)
+  if json == nil then
+    print("Response empty")
+  elseif json.error then
+    print("Error: " .. json.error.message)
+  elseif not json.choices or 0 == #json.choices or not json.choices[1].message then
+    print("Error: " .. vim.fn.json_encode(json))
+  else
+    local response_text = json.choices[1].message.content
+
+    if response_text ~= nil then
+      if type(response_text) ~= "string" or response_text == "" then
+        print("Error: No response text " .. type(response_text))
+      else
+        local bufnr = vim.api.nvim_get_current_buf()
+        cb(Utils.parse_lines(response_text))
+        if vim.g["codegpt_clear_visual_selection"] then
+            vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
+            vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
+        end
+      end
+    else
+      print("Error: No message")
+    end
+  end
+end
+
+return OpenAIProvider

--- a/lua/codegpt/utils.lua
+++ b/lua/codegpt/utils.lua
@@ -54,4 +54,39 @@ function Utils.replace_lines(lines)
   vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, lines)
 end
 
+local function get_code_block(lines2)
+  local code_block = {}
+  local in_code_block = false
+  for _, line in ipairs(lines2) do
+    if line:match("^```") then
+      in_code_block = not in_code_block
+    elseif in_code_block then
+      table.insert(code_block, line)
+    end
+  end
+  return code_block
+end
+
+local function contains_code_block(lines2)
+  for _, line in ipairs(lines2) do
+    if line:match("^```") then
+      return true
+    end
+  end
+  return false
+end
+
+function Utils.parse_lines(response_text)
+  if vim.g["codegpt_write_response_to_err_log"] then
+    vim.api.nvim_err_write("ChatGPT response: \n" .. response_text .. "\n")
+  end
+
+  local lines = vim.fn.split(response_text, "\n")
+  if contains_code_block(lines) then
+    return get_code_block(lines)
+  end
+
+  return lines
+end
+
 return Utils


### PR DESCRIPTION
Microsoft Azure offers OpenAI deployment and API, which may prompt some individuals (such as myself) to seek other providers that utilize the capabilities of GPT models. This pull request establishes Azure as an alternative provider.

FYI: https://learn.microsoft.com/en-us/azure/cognitive-services/openai

I am currently utilizing the fork version in my personal [dotfiles](https://github.com/yuchanns/nvim/blob/3dfae8fcf4388873f3304c7ff16e6d8e28fb8f65/lua/modules/completion/package.lua#L25-L29).

Tasks:
- [x] Introduce a global variable `codegpt_openai_api_provider` with a default value of `OpenAI`, while also providing `Azure` as an option.
- [x] Create request tables for various providers.
- [x] Manage responses based on different providers.


https://user-images.githubusercontent.com/25029451/225242838-b78d191c-4992-4f85-9824-350e5895d07b.mp4

