### PR TITLE
feat: allow parameters to be passed to custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ A full list of overrides
 | callback_type | "replace_lines" | Controls what the plugin does with the response |
 | language_instructions | {} | A table of filetype => instructions. The current buffer's filetype is used in this lookup. This is useful trigger different instructions for different languages. |
 
+
+#### Templates
+
+The `system_message_template` and the `user_message_template` can contain template macros. For example:
+
+| macro | description |
+|------|-------------|
+| `{{filetype}}` | The `filetype` of the current buffer. |
+| `{{text_selection}}` | The selected text in the current buffer. |
+| `{{language}}` | The name of the programming language in the current buffer. |
+| `{{command_args}}` | Everything passed to the command as an argument, joined with spaces. See below. |
+| `{{language_instructions}}` | The found value in the `language_instructions` map. See below. |
+
+
 #### Language Instructions
 
 Some commands have templates that use the `{{language_instructions}}` macro to allow for additional instructions for specific [filetypes](https://neovim.io/doc/user/filetype.html).
@@ -97,6 +111,22 @@ vim.g["codegpt_commands_defaults"] = {
 
 The above adds a specific `Use trailing return type.` to the command `completion` for the filetype `cpp`.
 
+
+#### Command Args
+
+Commands are normally a single value, for example `:Chat completion`. Normally, a command such as `:Chat completion value` will be interpreted as a `code_edit` command, with the arguments `"completion value"`, and not `completion` with `"value"`. You can make commands accept additional arguments by using the `{{command_args}}` macro anywhere in either `user_message_template` or `system_message_template`. For example:
+
+```lua
+vim.g["codegpt_commands"] = {
+  ["testwith"] = {
+      user_message_template = 
+        "Write tests for the following code: ```{{filetype}}\n{{text_selection}}```\n{{command_args}} " ..
+        "Only return the code snippet and nothing else."
+  }
+}
+```
+
+After defining this command, any `:Chat` command that has `testwith` as its first argument will be handled. For example, `:Chat testwith some additional instructions` will be interpreted as `testwith` with `"some additional instructions"`.
 
 
 ## Custom Commands

--- a/lua/codegpt.lua
+++ b/lua/codegpt.lua
@@ -3,35 +3,41 @@ local CommandsList = require("codegpt.commands_list")
 local Utils = require("codegpt.utils")
 local CodeGptModule = {}
 
+local function has_command_args(opts)
+	local pattern = "%{%{command_args%}%}"
+	return string.find(opts.user_template_message or "", pattern)
+      or string.find(opts.system_template_message or "", pattern)
+end
+
 function CodeGptModule.run_cmd(opts)
-  local text_selection = Utils.get_selected_lines()
-  local command_args = table.concat(opts.fargs, " ")
+	local text_selection = Utils.get_selected_lines()
+	local command_args = table.concat(opts.fargs, " ")
 
-  local command = ""
+	local command = opts.fargs[1]
 
-  if text_selection ~= "" and command_args ~= "" then
-    if 1 == #opts.fargs and CommandsList.get_cmd_opts(opts.fargs[1]) ~= nil then
-      command = opts.fargs[1]
-      command_args = ""
-    else
-      command = "code_edit"
-    end
-  elseif text_selection ~= "" and command_args == "" then
-    command = "completion"
-  elseif text_selection == "" and command_args ~= "" then
-    command = "chat"
-  end
+	if text_selection ~= "" and command_args ~= "" then
+		local cmd_opts = CommandsList.get_cmd_opts(command)
+		if cmd_opts and has_command_args(cmd_opts) then
+			command_args = table.concat(opts.fargs, " ", 2)
+		elseif cmd_opts and 1 == #opts.fargs then
+			command_args = ""
+		else
+			command = "code_edit"
+		end
+	elseif text_selection ~= "" and command_args == "" then
+		command = "completion"
+	elseif text_selection == "" and command_args ~= "" then
+		command = "chat"
+	end
 
-  if command == nil or command == "" then
-    error("Command not found")
-  end
+	if command == nil or command == "" then
+    vim.notify("No command or text selection provided", vim.log.levels.ERROR, {
+      title = "CodeGPT"
+    })
+    return
+	end
 
-  local cmd_opts = CommandsList.get_cmd_opts(command)
-  if cmd_opts == nil then
-    error("Command not found")
-  end
-
-  Commands.run_cmd(command, command_args, text_selection)
+	Commands.run_cmd(command, command_args, text_selection)
 end
 
 return CodeGptModule

--- a/lua/codegpt/commands.lua
+++ b/lua/codegpt/commands.lua
@@ -7,7 +7,10 @@ local Commands = {}
 function Commands.run_cmd(command, command_args, text_selection)
   local cmd_opts = CommandsList.get_cmd_opts(command)
   if cmd_opts == nil then
-      error("Command not found: " .. command)
+      vim.notify("Command not found: " .. command, vim.log.levels.ERROR, {
+        title = "CodeGPT"
+      })
+      return
   end
 
   local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -34,7 +34,7 @@ function CommandsList.get_cmd_opts(cmd)
     end
 
     if opts == nil and user_set_opts == nil then
-        error("No command options set")
+        return nil
     elseif opts == nil then
         opts = {}
     elseif user_set_opts == nil then


### PR DESCRIPTION
This allows parameters to be passed to custom commands, for example:

```lua
		vim.g.codegpt_commands = {
			test = {
				user_message_template = "I have the following {{language}} code: ... {{command_args}}. {{language_instructions}} Only return the unit tests. Only return the code snippet and nothing else. ",
				callback_type = "code_popup",
                -- ...
			},
		}
```

This can be invoked with `:Chat test some additional information that can help ChatGPT write better tests.`