### PR TITLE
popup commands

### DIFF
--- a/lua/codegpt/commands.lua
+++ b/lua/codegpt/commands.lua
@@ -5,15 +5,15 @@ local Providers = require("codegpt.providers")
 local Commands = {}
 
 function Commands.run_cmd(command, command_args, text_selection)
-  local cmd_opts = CommandsList.get_cmd_opts(command)
-  if cmd_opts == nil then
-    vim.notify("Command not found: " .. command, vim.log.levels.ERROR, {
-      title = "CodeGPT",
-    })
-    return
-  end
+	local cmd_opts = CommandsList.get_cmd_opts(command)
+	if cmd_opts == nil then
+		vim.notify("Command not found: " .. command, vim.log.levels.ERROR, {
+			title = "CodeGPT",
+		})
+		return
+	end
 
-  local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)
+	local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)
 
   local bufnr = vim.api.nvim_get_current_buf()
   local start_row, start_col, end_row, end_col = Utils.get_visual_selection()
@@ -24,7 +24,7 @@ function Commands.run_cmd(command, command_args, text_selection)
 end
 
 function Commands.get_status(...)
-  return OpenAiApi.get_status(...)
+	return OpenAiApi.get_status(...)
 end
 
 return Commands

--- a/lua/codegpt/commands.lua
+++ b/lua/codegpt/commands.lua
@@ -5,21 +5,26 @@ local Providers = require("codegpt.providers")
 local Commands = {}
 
 function Commands.run_cmd(command, command_args, text_selection)
-	local cmd_opts = CommandsList.get_cmd_opts(command)
-	if cmd_opts == nil then
-		vim.notify("Command not found: " .. command, vim.log.levels.ERROR, {
-			title = "CodeGPT",
-		})
-		return
-	end
+  local cmd_opts = CommandsList.get_cmd_opts(command)
+  if cmd_opts == nil then
+    vim.notify("Command not found: " .. command, vim.log.levels.ERROR, {
+      title = "CodeGPT",
+    })
+    return
+  end
 
-	local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)
+  local request = Providers.get_provider().make_request(command, cmd_opts, command_args, text_selection)
 
-	OpenAiApi.make_call(request, cmd_opts.callback)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local start_row, start_col, end_row, end_col = Utils.get_visual_selection()
+  local new_callback = function(lines)
+    cmd_opts.callback(lines, bufnr, start_row, start_col, end_row, end_col)
+  end
+  OpenAiApi.make_call(request, new_callback)
 end
 
 function Commands.get_status(...)
-	return OpenAiApi.get_status(...)
+  return OpenAiApi.get_status(...)
 end
 
 return Commands

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -3,60 +3,60 @@ local Ui = require("codegpt.ui")
 
 local CommandsList = {}
 local cmd_default = {
-	model = "gpt-3.5-turbo",
-	max_tokens = 4096,
-	temperature = 0.8,
-	number_of_choices = 1,
-	system_message_template = "You are a {{language}} coding assistant.",
-	user_message_template = "",
-	callback_type = "replace_lines",
+  model = "gpt-3.5-turbo",
+  max_tokens = 4096,
+  temperature = 0.8,
+  number_of_choices = 1,
+  system_message_template = "You are a {{language}} coding assistant.",
+  user_message_template = "",
+  callback_type = "replace_lines",
 }
 
 CommandsList.CallbackTypes = {
-	["text_popup"] = function(lines)
-		Ui.popup(lines, "text")
-	end,
-	["code_popup"] = function(lines)
-		Ui.popup(lines, Utils.get_filetype())
-	end,
-	["replace_lines"] = function(lines)
-		Utils.replace_lines(lines)
-	end,
-	["custom"] = nil,
+  ["text_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
+    Ui.popup(lines, "text", bufnr, start_row, start_col, end_row, end_col)
+  end,
+  ["code_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
+    Ui.popup(lines, Utils.get_filetype(), bufnr, start_row, start_col, end_row, end_col)
+  end,
+  ["replace_lines"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
+    Utils.replace_lines(lines, bufnr, start_row, start_col, end_row, end_col)
+  end,
+  ["custom"] = nil,
 }
 
 function CommandsList.get_cmd_opts(cmd)
-	local opts = vim.g["codegpt_commands_defaults"][cmd]
-	local user_set_opts = {}
+  local opts = vim.g["codegpt_commands_defaults"][cmd]
+  local user_set_opts = {}
 
-	if vim.g["codegpt_commands"] ~= nil then
-		user_set_opts = vim.g["codegpt_commands"][cmd]
-	end
+  if vim.g["codegpt_commands"] ~= nil then
+    user_set_opts = vim.g["codegpt_commands"][cmd]
+  end
 
-	if opts == nil and user_set_opts == nil then
-		return nil
-	elseif opts == nil then
-		opts = {}
-	elseif user_set_opts == nil then
-		user_set_opts = {}
-	elseif opts ~= nil and user_set_opts ~= nil then
-		-- merge language_instructions
-		if opts.language_instructions ~= nil and user_set_opts.language_instructions ~= nil then
-			user_set_opts.language_instructions =
-				vim.tbl_extend("force", opts.language_instructions, user_set_opts.language_instructions)
-		end
-	end
+  if opts == nil and user_set_opts == nil then
+    return nil
+  elseif opts == nil then
+    opts = {}
+  elseif user_set_opts == nil then
+    user_set_opts = {}
+  elseif opts ~= nil and user_set_opts ~= nil then
+    -- merge language_instructions
+    if opts.language_instructions ~= nil and user_set_opts.language_instructions ~= nil then
+      user_set_opts.language_instructions =
+          vim.tbl_extend("force", opts.language_instructions, user_set_opts.language_instructions)
+    end
+  end
 
-	opts = vim.tbl_extend("force", opts, user_set_opts)
-	opts = vim.tbl_extend("force", cmd_default, opts)
+  opts = vim.tbl_extend("force", opts, user_set_opts)
+  opts = vim.tbl_extend("force", cmd_default, opts)
 
-	if opts.callback_type == "custom" then
-		opts.callback = user_set_opts.callback
-	else
-		opts.callback = CommandsList.CallbackTypes[opts.callback_type]
-	end
+  if opts.callback_type == "custom" then
+    opts.callback = user_set_opts.callback
+  else
+    opts.callback = CommandsList.CallbackTypes[opts.callback_type]
+  end
 
-	return opts
+  return opts
 end
 
 return CommandsList

--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -62,3 +62,11 @@ vim.g["codegpt_commands_defaults"] = {
 		callback_type = "text_popup",
 	},
 }
+
+-- Popup commands
+vim.g["codegpt_ui_commands"] = {
+  quit = 'q',
+  use_as_output = '<c-o>',
+  use_as_input = '<c-i>'
+}
+vim.g["codegpt_ui_custom_commands"] = {}

--- a/lua/codegpt/openai_api.lua
+++ b/lua/codegpt/openai_api.lua
@@ -58,7 +58,7 @@ local function curl_callback(response, cb)
 	run_finished_hook()
 end
 
-function OpenAIApi.make_call(payload, cb)
+function OpenAIApi.make_call(payload, cb, selection)
 	local payload_str = vim.fn.json_encode(payload)
 	local url = vim.g["codegpt_chat_completions_url"]
 	local headers = Providers.get_provider().make_headers()
@@ -69,7 +69,7 @@ function OpenAIApi.make_call(payload, cb)
 		body = payload_str,
 		headers = headers,
 		callback = function(response)
-			curl_callback(response, cb)
+			curl_callback(response, cb, selection)
 		end,
 	})
 end

--- a/lua/codegpt/openai_api.lua
+++ b/lua/codegpt/openai_api.lua
@@ -58,7 +58,7 @@ local function curl_callback(response, cb)
 	run_finished_hook()
 end
 
-function OpenAIApi.make_call(payload, cb, selection)
+function OpenAIApi.make_call(payload, cb)
 	local payload_str = vim.fn.json_encode(payload)
 	local url = vim.g["codegpt_chat_completions_url"]
 	local headers = Providers.get_provider().make_headers()
@@ -69,7 +69,7 @@ function OpenAIApi.make_call(payload, cb, selection)
 		body = payload_str,
 		headers = headers,
 		callback = function(response)
-			curl_callback(response, cb, selection)
+			curl_callback(response, cb)
 		end,
 	})
 end

--- a/lua/codegpt/ui.lua
+++ b/lua/codegpt/ui.lua
@@ -19,23 +19,40 @@ local popup = Popup({
 	},
 })
 
-function Ui.popup(lines, filetype)
-	-- mount/open the component
-	popup:mount()
+function Ui.popup(lines, filetype, bufnr, start_row, start_col, end_row, end_col)
+  -- mount/open the component
+  popup:mount()
 
-	-- unmount component when cursor leaves buffer
-	popup:on(event.BufLeave, function()
-		popup:unmount()
-	end)
+  -- unmount component when cursor leaves buffer
+  popup:on(event.BufLeave, function()
+    popup:unmount()
+  end)
 
-	-- unmount component when key 'q'
-	popup:map("n", "q", function()
-		popup:unmount()
-	end, { noremap = true, silent = true })
+  -- unmount component when key 'q'
+  popup:map("n", vim.g["codegpt_ui_commands"].quit, function()
+    popup:unmount()
+  end, { noremap = true, silent = true })
 
-	-- set content
-	vim.api.nvim_buf_set_option(popup.bufnr, "filetype", filetype)
-	vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, lines)
+  -- set content
+  vim.api.nvim_buf_set_option(popup.bufnr, "filetype", filetype)
+  vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, lines)
+
+  -- replace lines when ctrl-o pressed
+  popup:map("n", vim.g["codegpt_ui_commands"].use_as_output, function()
+    vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, lines)
+    popup:unmount()
+  end)
+
+  -- selecting all the content when ctrl-i is pressed
+  -- so the user can proceed with another API request
+  popup:map("n", vim.g["codegpt_ui_commands"].use_as_input, function()
+    vim.api.nvim_feedkeys('ggVG:Chat ', 'n', false)
+  end, { noremap = false })
+
+  -- mapping custom commands
+  for _, command in ipairs(vim.g.codegpt_ui_custom_commands) do
+    popup:map(command[1], command[2], command[3], command[4])
+  end
 end
 
 return Ui

--- a/lua/codegpt/utils.lua
+++ b/lua/codegpt/utils.lua
@@ -48,9 +48,7 @@ function Utils.insert_lines(lines)
 	vim.api.nvim_win_set_cursor(0, { line + #lines, 0 })
 end
 
-function Utils.replace_lines(lines)
-	local bufnr = vim.api.nvim_get_current_buf()
-	local start_row, start_col, end_row, end_col = Utils.get_visual_selection()
+function Utils.replace_lines(lines, bufnr, start_row, start_col, end_row, end_col)
 	vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, lines)
 end
 


### PR DESCRIPTION
This pull request introduces custom popup commands and 2 new default commands for popup windows, namely:
* C-o to use the popup content as output (replacing the lines)
* C-i to use the popup content as input of a new API call (selecting the whole content and prompting to the command line)

It actually also solves an existing problem when the user changes the buffer before the answer arrives: this pull request solves the issue by computing the point where the lines should be changed before running the request.