### PR TITLE
feat: add support for Azure GPT-4

### DIFF
--- a/lua/codegpt/providers/azure.lua
+++ b/lua/codegpt/providers/azure.lua
@@ -3,10 +3,7 @@ local Utils = require("codegpt.utils")
 
 AzureProvider = {}
 
-local function generate_messages(command, cmd_opts, command_args, text_selection)
-	local system_message = Render.render(command, cmd_opts.system_message_template, command_args, text_selection)
-	local user_message = Render.render(command, cmd_opts.user_message_template, command_args, text_selection)
-
+local function generate_messages_legacy(command, cmd_opts, command_args, text_selection, system_message, user_message)
 	local prompt = ""
 	if system_message ~= nil and system_message ~= "" then
 		prompt = "<|im_start|>" .. prompt .. "system\n" .. system_message .. "\n<|im_end|>\n"
@@ -19,8 +16,56 @@ local function generate_messages(command, cmd_opts, command_args, text_selection
 	return prompt
 end
 
-local function get_max_tokens(max_tokens, messages)
+local function is_legacy()
+	-- Azure OpenAI supports multiple APIs.
+	-- We should check if `codegpt_chat_completions_url` is match
+	-- `/deployments/{deployment-id}/chat/completions`
+	-- If not, should use the legacy parameters
+	local completions_url = vim.g["codegpt_chat_completions_url"]
+
+	return vim.fn.match(completions_url, "/chat/completions") == -1
+end
+
+local function generate_messages(command, cmd_opts, command_args, text_selection)
+	local system_message = Render.render(command, cmd_opts.system_message_template, command_args, text_selection)
+	local user_message = Render.render(command, cmd_opts.user_message_template, command_args, text_selection)
+	if is_legacy() then
+		return generate_messages_legacy(command, cmd_opts, command_args, text_selection, system_message, user_message)
+	end
+
+	local prompt = {}
+	if system_message ~= nil and system_message ~= "" then
+		table.insert(prompt, { role = "system", content = system_message })
+	end
+
+	if user_message ~= nil and user_message ~= "" then
+		table.insert(prompt, { role = "user", content = user_message })
+	end
+
+	return prompt
+end
+
+local function get_max_tokens_legacy(max_tokens, messages)
 	local total_length = string.len(messages)
+
+	if total_length >= max_tokens then
+		error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_tokens)
+	end
+
+	return max_tokens - total_length
+end
+
+local function get_max_tokens(max_tokens, messages)
+	if is_legacy() then
+		return get_max_tokens_legacy(max_tokens, messages)
+	end
+
+	local total_length = 0
+
+	for _, message in ipairs(messages) do
+		total_length = total_length + string.len(message.content)
+		total_length = total_length + string.len(message.role)
+	end
 
 	if total_length >= max_tokens then
 		error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_tokens)
@@ -37,10 +82,14 @@ function AzureProvider.make_request(command, cmd_opts, command_args, text_select
 		temperature = cmd_opts.temperature,
 		n = cmd_opts.number_of_choices,
 		model = cmd_opts.model,
-		prompt = messages,
 		max_tokens = max_tokens,
-		stop = "<|im_end|>",
 	}
+	if is_legacy() then
+		request["stop"] = "<|im_end|>"
+		request["prompt"] = messages
+	else
+		request["messages"] = messages
+	end
 
 	return request
 end
@@ -56,30 +105,59 @@ function AzureProvider.make_headers()
 	return { Content_Type = "application/json", ["api-key"] = token }
 end
 
+local function handle_response_legacy(json, cb)
+	if not json.choices or 0 == #json.choices or not json.choices[1].text then
+		print("Error: " .. vim.fn.json_encode(json))
+		return
+	end
+
+	local response_text = json.choices[1].text
+	if response_text ~= nil then
+		if type(response_text) ~= "string" or response_text == "" then
+			print("Error: No response text " .. type(response_text))
+		else
+			local bufnr = vim.api.nvim_get_current_buf()
+			cb(Utils.parse_lines(response_text))
+			if vim.g["codegpt_clear_visual_selection"] then
+				vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
+				vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
+			end
+		end
+	else
+		print("Error: No message")
+	end
+end
+
 function AzureProvider.handle_response(json, cb)
 	if json == nil then
 		print("Response empty")
 	elseif json.error then
 		print("Error: " .. json.error.message)
-	elseif not json.choices or 0 == #json.choices or not json.choices[1].text then
-		print("Error: " .. vim.fn.json_encode(json))
-	else
-		local response_text = json.choices[1].text
+	end
+	if is_legacy() then
+		return handle_response_legacy(json, cb)
+	end
 
-		if response_text ~= nil then
-			if type(response_text) ~= "string" or response_text == "" then
-				print("Error: No response text " .. type(response_text))
-			else
-				local bufnr = vim.api.nvim_get_current_buf()
-				cb(Utils.parse_lines(response_text))
-				if vim.g["codegpt_clear_visual_selection"] then
-					vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
-					vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
-				end
-			end
+	if not json.choices or 0 == #json.choices or not json.choices[1].message then
+		print("Error: " .. vim.fn.json_encode(json))
+		return
+	end
+
+	local response_text = json.choices[1].message.content
+
+	if response_text ~= nil then
+		if type(response_text) ~= "string" or response_text == "" then
+			print("Error: No response text " .. type(response_text))
 		else
-			print("Error: No message")
+			local bufnr = vim.api.nvim_get_current_buf()
+			cb(Utils.parse_lines(response_text))
+			if vim.g["codegpt_clear_visual_selection"] then
+				vim.api.nvim_buf_set_mark(bufnr, "<", 0, 0, {})
+				vim.api.nvim_buf_set_mark(bufnr, ">", 0, 0, {})
+			end
 		end
+	else
+		print("Error: No message")
 	end
 end
 


### PR DESCRIPTION
The Azure OpenAI Service offers a new interface for GPT-4, ensuring consistency with OpenAI's API.

The updated API is `/deployments/{deployment-id}/chat/completions`, replacing the previous `/deployments/{deployment-id}/completions`.

Notable differences between the two versions involve the request body and response.

With this PR, three valid `codegpt_chat_completions_url` options are available:
* GPT3.5 Legacy API: `https://{your-resource}.azure.com/openai/deployments/{gpt-3.5-model-id}/completions?api-version=2023-03-15-preview`
	<details>
	<summary>Click to view the screenshot</summary>
	
	![2023-04-04_13-26](https://user-images.githubusercontent.com/25029451/229696971-4532dfbf-b13a-44ba-92aa-9545c0ac5e2a.png)
	</details>

* GPT3.5 New API: `https://{your-resource}.openai.azure.com/openai/deployments/{gpt-3.5-model-id}/chat/completions?api-version=2023-03-15-preview`
	<details>
	<summary>Click to view the screenshot</summary>
	
	![2023-04-04_13-25](https://user-images.githubusercontent.com/25029451/229697043-6420e5dd-10b3-48d8-9782-2e5814b0d7a8.png)
	</details>

* GPT4 New API: `https://{your-resource}.openai.azure.com/openai/deployments/{gpt-4-model-id}/chat/completions?api-version=2023-03-15-preview`
	<details>
	<summary>Click to view the screenshot</summary>
	
	![2023-04-04_13-23](https://user-images.githubusercontent.com/25029451/229697132-4403e137-b100-431a-95c6-ecf7714c5ed0.png)
	</details>


FYI:

* stable/[2022-12-01] API ([Azure/azure-rest-api-specs@main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01?rgh-link-date=2023-03-27T18%3A42%3A59Z)) [Azure/azure-rest-api-specs@main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/inference.json](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/inference.json?rgh-link-date=2023-03-27T18%3A42%3A59Z)

* preview/[2023-03-15-preview](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-03-15-preview?rgh-link-date=2023-03-27T18%3A42%3A59Z) API [Azure/azure-rest-api-specs@main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-03-15-preview/inference.json](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-03-15-preview/inference.json?rgh-link-date=2023-03-27T18%3A42%3A59Z)