### PR TITLE
Fixed code extraction in code popup

### DIFF
--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -19,7 +19,6 @@ CommandsList.CallbackTypes = {
         Ui.popup(lines, popup_filetype, bufnr, start_row, start_col, end_row, end_col)
     end,
     ["code_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
-        Utils.fix_indentation(bufnr, start_row, end_row, lines)
         Ui.popup(Utils.trim_to_code_block(lines), Utils.get_filetype(), bufnr, start_row, start_col, end_row, end_col)
     end,
     ["replace_lines"] = function(lines, bufnr, start_row, start_col, end_row, end_col)

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -20,11 +20,9 @@ CommandsList.CallbackTypes = {
     end,
     ["code_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
         Ui.popup(Utils.trim_to_code_block(lines), Utils.get_filetype(), bufnr, start_row, start_col, end_row, end_col)
-        Utils.fix_indentation(bufnr, start_row, end_row, lines)
     end,
     ["replace_lines"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
         lines = Utils.trim_to_code_block(lines)
-        Utils.fix_indentation(bufnr, start_row, end_row, lines)
         if vim.api.nvim_buf_is_valid(bufnr) == true then
             Utils.replace_lines(lines, bufnr, start_row, start_col, end_row, end_col)
         else

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -20,10 +20,11 @@ CommandsList.CallbackTypes = {
     end,
     ["code_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
         Ui.popup(Utils.trim_to_code_block(lines), Utils.get_filetype(), bufnr, start_row, start_col, end_row, end_col)
+        Utils.fix_indentation(bufnr, start_row, end_row, lines)
     end,
     ["replace_lines"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
-        Utils.fix_indentation(bufnr, start_row, end_row, lines)
         lines = Utils.trim_to_code_block(lines)
+        Utils.fix_indentation(bufnr, start_row, end_row, lines)
         if vim.api.nvim_buf_is_valid(bufnr) == true then
             Utils.replace_lines(lines, bufnr, start_row, start_col, end_row, end_col)
         else


### PR DESCRIPTION
hey @dpayne!

minor fix. somehow, trimming doesn't work for indented code blocks.
 
please let me know if this makes sense.

- before
![image](https://user-images.githubusercontent.com/1897055/231873501-ebb0323a-a4f4-471b-84a8-f12e4d954450.png)

- after
![image](https://user-images.githubusercontent.com/1897055/231873454-cecb892f-3f3e-4408-8778-e97fca926e09.png)
