### PR TITLE
Added accurate token count estimate using tiktoken

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ CodeGPT is a plugin for neovim that provides commands to interact with ChatGPT. 
 
 * Set environment variable `OPENAI_API_KEY` to your [openai api key](https://platform.openai.com/account/api-keys).
 * The plugins 'plenary' and 'nui' are also required.
+* OpenAI's tokenizer [tiktoken](https://github.com/openai/tiktoken) is recommended for accurate token count estimate.
 
 Installing with Lazy.
 
@@ -36,6 +37,11 @@ Installing with plugged.
 Plug("nvim-lua/plenary.nvim")
 Plug("MunifTanjim/nui.nvim")
 Plug("dpayne/CodeGPT.nvim")
+```
+
+Installing OpenAI's tokenizer
+```sh
+pip install tiktoken
 ```
 
 ## Commands

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -15,7 +15,6 @@ local cmd_default = {
 CommandsList.CallbackTypes = {
     ["text_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)
         local popup_filetype = vim.g["codegpt_text_popup_filetype"]
-        Utils.fix_indentation(bufnr, start_row, end_row, lines)
         Ui.popup(lines, popup_filetype, bufnr, start_row, start_col, end_row, end_col)
     end,
     ["code_popup"] = function(lines, bufnr, start_row, start_col, end_row, end_col)

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -21,11 +21,23 @@ local function generate_messages(command, cmd_opts, command_args, text_selection
 end
 
 local function get_max_tokens(max_tokens, messages)
-    local total_length = 0
+    local ok, result = pcall(vim.api.nvim_exec, string.format([[
+python3 << EOF
+import tiktoken
+encoder = tiktoken.get_encoding("cl100k_base")
+encoded = encoder.encode("""%s""")
+print(len(encoded))
+EOF
+]], vim.fn.json_encode(messages)), true)
 
-    for _, message in ipairs(messages) do
-        total_length = total_length + string.len(message.content)
-        total_length = total_length + string.len(message.role)
+    local total_length = 0
+    if ok then
+        total_length = tonumber(result)
+    else
+        for _, message in ipairs(messages) do
+            total_length = total_length + string.len(message.content)
+            total_length = total_length + string.len(message.role)
+        end
     end
 
     if total_length >= max_tokens then


### PR DESCRIPTION
this pr addresses https://github.com/dpayne/CodeGPT.nvim/issues/36.

if `tiktoken` is not installed, token count estimate falls back to the original approach.

there is still the hard limit of 4096 tokens for the API, so even though this pr allows larger prompts,  it also leads to smaller and incomplete responses because the hard limit is shared between prompts and responses.