### PR TITLE
Call `run_finished_hook` on error situations.

### DIFF
--- a/lua/codegpt/openai_api.lua
+++ b/lua/codegpt/openai_api.lua
@@ -71,6 +71,10 @@ function OpenAIApi.make_call(payload, cb)
         callback = function(response)
             curl_callback(response, cb)
         end,
+        on_error = function(err)
+            print('Error:', err.message)
+            run_finished_hook()
+        end,
     })
 end
 


### PR DESCRIPTION
The function `run_finished_hook` is not currently called when errors occur. This can result in the creation of states in the `on_started_hook` function that cannot be cleaned up after the request ends, regardless of its success. Therefore, it is necessary to add the `run_finished_hook` function to the error handling path.
