### PR TITLE
feat：Add OPENAI_API_ENDPOINT parameter 

### DIFF
--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -1,7 +1,11 @@
 if os.getenv("OPENAI_API_KEY") ~= nil then
     vim.g["codegpt_openai_api_key"] = os.getenv("OPENAI_API_KEY")
 end
+
 vim.g["codegpt_chat_completions_url"] = "https://api.openai.com/v1/chat/completions"
+if os.getenv("OPENAI_API_ENDPOINT") ~= nil then
+    vim.g["codegpt_chat_completions_url"] = os.getenv("OPENAI_API_ENDPOINT")
+end
 
 -- alternative provider
 vim.g["codegpt_openai_api_provider"] = "OpenAI"


### PR DESCRIPTION
This PR introduces a new parameter `OPENAI_API_ENDPOINT`. This addition allows the users to conveniently configure the endpoint for OpenAI's API, thereby expanding the versatility of the code to potentially interact with a server set up by the user.

The default value of the parameter is "https://api.openai.com/v1/chat/completions" catering to general requests to OpenAI API. But it can be tailored according to specific needs, offering flexibility with environment switches.

