### PR TITLE
OpenAI: allow sending custom params to remote API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,35 @@ The above, overrides the message template for the `completion` command.
 
 A full list of overrides
 
-| name | default | description |
-|------|---------|-------------|
-| model | "gpt-3.5-turbo" | The model to use. |
-| max_tokens | 4096 | The maximum number of tokens to use including the prompt tokens. |
-| temperature | 0.6 | 0 -> 1, what sampling temperature to use. |
-| system_message_template | "" | Helps set the behavior of the assistant. |
-| user_message_template | "" | Instructs the assistant. |
-| callback_type | "replace_lines" | Controls what the plugin does with the response |
-| language_instructions | {} | A table of filetype => instructions. The current buffer's filetype is used in this lookup. This is useful trigger different instructions for different languages. |
+| name                    | default         | description                                                                                                                                                       |
+|-------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| model                   | "gpt-3.5-turbo" | The model to use.                                                                                                                                                 |
+| max_tokens              | 4096            | The maximum number of tokens to use including the prompt tokens.                                                                                                  |
+| temperature             | 0.6             | 0 -> 1, what sampling temperature to use.                                                                                                                         |
+| system_message_template | ""              | Helps set the behavior of the assistant.                                                                                                                          |
+| user_message_template   | ""              | Instructs the assistant.                                                                                                                                          |
+| callback_type           | "replace_lines" | Controls what the plugin does with the response                                                                                                                   |
+| language_instructions   | {}              | A table of filetype => instructions. The current buffer's filetype is used in this lookup. This is useful trigger different instructions for different languages. |
+| extra_params            | {}              | A table of custom parameters to be sent to the API.                                                                                                               |
+
+
+
+### Overriding the global defaults
+
+The overrides can be set globally using `vim.g["codegpt_global_commands_defaults"]`. This can be useful to setup a custom configuration for APIs that emulate OpenAI such as LocalAI.
+
+```lua
+    vim.g["codegpt_global_commands_defaults"] = { 
+        model = "mixtral",
+        max_tokens = 4096,
+        temperature = 0.4,
+        -- extra_parms = { -- optional list of extra parameters to send to the API
+        --     presence_penalty = 1,
+        --     frequency_penalty= 1
+        -- }
+    }
+```
+
 
 
 #### Templates

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -10,6 +10,7 @@ local cmd_default = {
     system_message_template = "You are a {{language}} coding assistant.",
     user_message_template = "",
     callback_type = "replace_lines",
+    extra_params = {}, -- extra parameters sent to the API
 }
 
 CommandsList.CallbackTypes = {
@@ -38,6 +39,7 @@ CommandsList.CallbackTypes = {
 function CommandsList.get_cmd_opts(cmd)
     local opts = vim.g["codegpt_commands_defaults"][cmd]
     local user_set_opts = {}
+    local cmd_default = vim.tbl_extend("force", cmd_default, vim.g["codegpt_global_commands_defaults"])
 
     if vim.g["codegpt_commands"] ~= nil then
         user_set_opts = vim.g["codegpt_commands"][cmd]

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -49,6 +49,7 @@ function OpenAIProvider.make_request(command, cmd_opts, command_args, text_selec
         max_tokens = max_tokens,
     }
 
+    request = vim.tbl_extend("force", request, cmd_opts.extra_params)
     return request
 end
 


### PR DESCRIPTION
Allow passing extra params to OpenAI API. Especially useful with APIs that emulate OpenAI such as LocalAI.
