### PR TITLE
Fix unusable Provider Azure

### DIFF
--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -117,7 +117,7 @@ end
 
 function OpenAIProvider.make_call(payload, cb)
     local payload_str = vim.fn.json_encode(payload)
-    local url = "https://api.openai.com/v1/chat/completions"
+    local url = vim.g["codegpt_chat_completions_url"]
     local headers = OpenAIProvider.make_headers()
     Api.run_started_hook()
     curl.post(url, {


### PR DESCRIPTION
The commit https://github.com/dpayne/CodeGPT.nvim/commit/30ece5a970551a9a810566e28fd3473b3e4a0cbb broke the Provider Azure and disabled the configurable `codegpt_chat_completions_url`.

PR to fix it.