### PR TITLE
fix '%' are removed incorrectly from template values

### DIFF
--- a/lua/codegpt/template_render.lua
+++ b/lua/codegpt/template_render.lua
@@ -19,6 +19,12 @@ local function safe_replace(template, key, value)
     if type(value) == "table" then
         value = table.concat(value, "\n")
     end
+
+    if value then
+        -- Replace '%' with '%%' to escape it in the template
+        value = value:gsub("%%", "%%%%")
+    end
+
     return template:gsub(key, value)
 end
 


### PR DESCRIPTION
If the LLM output contains '%', that character is removed from the output before being inserted into the buffer.

this commit fixes that issue.