### PR TITLE
fix nil error for deprecated function

### DIFF
--- a/lua/codegpt/utils.lua
+++ b/lua/codegpt/utils.lua
@@ -111,7 +111,7 @@ end
 
 function Utils.get_accurate_tokens(content)
     local ok, result = pcall(
-        vim.api.nvim_exec,
+        vim.api.nvim_exec2,
         string.format([[
 python3 << EOF
 import tiktoken


### PR DESCRIPTION
vim.api.nvim_exc is deprecated in v0.10.0-dev-3045+gefaf37a2b, uptate to vim.api.nvim_exc2。and it waill raise an error with deprecated nvim_exc