### PR TITLE
output max token config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A full list of overrides
 |-------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | model                   | "gpt-3.5-turbo" | The model to use.                                                                                                                                                 |
 | max_tokens              | 4096            | The maximum number of tokens to use including the prompt tokens.                                                                                                  |
+| max_output_tokens       | nil             | To define max output tokens, excluding the prompt tokens. When this is not nil, `max_tokens` is the input tokens limit and this is the output tokens limit.       |
 | temperature             | 0.6             | 0 -> 1, what sampling temperature to use.                                                                                                                         |
 | system_message_template | ""              | Helps set the behavior of the assistant.                                                                                                                          |
 | user_message_template   | ""              | Instructs the assistant.                                                                                                                                          |

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -12,6 +12,10 @@ local cmd_default = {
     callback_type = "replace_lines",
     allow_empty_text_selection = false,
     extra_params = {}, -- extra parameters sent to the API
+
+    check_context_length = false,
+    max_context_length = 128 * 1024,
+    max_tokens_include_context = true,
 }
 
 CommandsList.CallbackTypes = {

--- a/lua/codegpt/commands_list.lua
+++ b/lua/codegpt/commands_list.lua
@@ -13,9 +13,9 @@ local cmd_default = {
     allow_empty_text_selection = false,
     extra_params = {}, -- extra parameters sent to the API
 
-    check_context_length = false,
-    max_context_length = 128 * 1024,
-    max_tokens_include_context = true,
+    -- Newer models have longer limit for input tokens and shorter limit for output tokens
+    -- Use this value for output tokens limit, and `max_tokens` for input tokens limit
+    max_output_tokens = nil,
 }
 
 CommandsList.CallbackTypes = {

--- a/lua/codegpt/providers/groq.lua
+++ b/lua/codegpt/providers/groq.lua
@@ -59,19 +59,14 @@ end
 function GroqProvider.make_request(command, cmd_opts, command_args, text_selection)
     local messages = generate_messages(command, cmd_opts, command_args, text_selection)
 
-    local max_tokens = cmd_opts.max_tokens or 4096
-    local max_tokens_include_context = cmd_opts.max_tokens_include_context or true
-    local max_context_length = cmd_opts.max_context_length or 128 * 1024
-    local check_context_length = cmd_opts.check_context_length or false
-
-    if max_tokens_include_context then
+    if cmd_opts.max_tokens_include_context then
         max_tokens = get_max_output_tokens(cmd_opts.max_tokens, messages)
     else
         max_tokens = cmd_opts.max_tokens
     end
 
-    if check_context_length then
-        fail_if_exceed_context_window(max_context_length, messages)
+    if cmd_opts.check_context_length then
+        fail_if_exceed_context_window(cmd_opts.max_context_length, messages)
     end
 
     local request = {

--- a/lua/codegpt/providers/groq.lua
+++ b/lua/codegpt/providers/groq.lua
@@ -22,7 +22,7 @@ local function generate_messages(command, cmd_opts, command_args, text_selection
     return messages
 end
 
-local function get_max_output_tokens(max_tokens, messages)
+local function get_max_tokens(max_tokens, messages)
     local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
 
     if not ok then

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -57,21 +57,14 @@ end
 function OpenAIProvider.make_request(command, cmd_opts, command_args, text_selection)
     local messages = generate_messages(command, cmd_opts, command_args, text_selection)
 
-    local max_tokens = cmd_opts.max_tokens or 4096
-    local max_tokens_include_context = cmd_opts.max_tokens_include_context or true
-    local max_context_length = cmd_opts.max_context_length or 128 * 1024
-    local check_context_length = cmd_opts.check_context_length or false
-
-    -- After gpt-4o, context is 128k+ while max output length is 4k+
-    -- Add this check here for backward compatibility and allow use to use the newer models
-    if max_tokens_include_context then
+    if cmd_opts.max_tokens_include_context then
         max_tokens = get_max_output_tokens(cmd_opts.max_tokens, messages)
     else
         max_tokens = cmd_opts.max_tokens
     end
 
-    if check_context_length then
-        fail_if_exceed_context_window(max_tokens, messages)
+    if cmd_opts.check_context_length then
+        fail_if_exceed_context_window(cmd_opts.max_context_length, messages)
     end
 
     local request = {

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -22,7 +22,7 @@ local function generate_messages(command, cmd_opts, command_args, text_selection
     return messages
 end
 
-local function get_max_tokens(max_tokens, messages)
+local function get_max_output_tokens(max_tokens, messages)
     local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
 
     if not ok then
@@ -39,9 +39,40 @@ local function get_max_tokens(max_tokens, messages)
     return max_tokens - total_length
 end
 
+local function fail_if_exceed_context_window(max_context_length, messages)
+    local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
+
+    if not ok then
+        for _, message in ipairs(messages) do
+            total_length = total_length + string.len(message.content)
+            total_length = total_length + string.len(message.role)
+        end
+    end
+
+    if total_length >= max_context_length then
+        error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_context_length)
+    end
+end
+
 function OpenAIProvider.make_request(command, cmd_opts, command_args, text_selection)
     local messages = generate_messages(command, cmd_opts, command_args, text_selection)
-    local max_tokens = get_max_tokens(cmd_opts.max_tokens, messages)
+
+    local max_tokens = cmd_opts.max_tokens or 4096
+    local max_tokens_include_context = cmd_opts.max_tokens_include_context or true
+    local max_context_length = cmd_opts.max_context_length or 128 * 1024
+    local check_context_length = cmd_opts.check_context_length or false
+
+    -- After gpt-4o, context is 128k+ while max output length is 4k+
+    -- Add this check here for backward compatibility and allow use to use the newer models
+    if max_tokens_include_context then
+        max_tokens = get_max_output_tokens(cmd_opts.max_tokens, messages)
+    else
+        max_tokens = cmd_opts.max_tokens
+    end
+
+    if check_context_length then
+        fail_if_exceed_context_window(max_tokens, messages)
+    end
 
     local request = {
         temperature = cmd_opts.temperature,

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -22,7 +22,7 @@ local function generate_messages(command, cmd_opts, command_args, text_selection
     return messages
 end
 
-local function get_max_output_tokens(max_tokens, messages)
+local function get_max_tokens(max_tokens, messages)
     local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
 
     if not ok then

--- a/lua/codegpt/providers/openai.lua
+++ b/lua/codegpt/providers/openai.lua
@@ -39,32 +39,15 @@ local function get_max_output_tokens(max_tokens, messages)
     return max_tokens - total_length
 end
 
-local function fail_if_exceed_context_window(max_context_length, messages)
-    local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
-
-    if not ok then
-        for _, message in ipairs(messages) do
-            total_length = total_length + string.len(message.content)
-            total_length = total_length + string.len(message.role)
-        end
-    end
-
-    if total_length >= max_context_length then
-        error("Total length of messages exceeds max_tokens: " .. total_length .. " > " .. max_context_length)
-    end
-end
-
 function OpenAIProvider.make_request(command, cmd_opts, command_args, text_selection)
     local messages = generate_messages(command, cmd_opts, command_args, text_selection)
 
-    if cmd_opts.max_tokens_include_context then
-        max_tokens = get_max_output_tokens(cmd_opts.max_tokens, messages)
+    local max_tokens = cmd_opts.max_tokens
+    if cmd_opts.max_output_tokens ~= nil then
+        Utils.fail_if_exceed_context_window(cmd_opts.max_tokens, messages)
+        max_tokens = cmd_opts.max_output_tokens
     else
-        max_tokens = cmd_opts.max_tokens
-    end
-
-    if cmd_opts.check_context_length then
-        fail_if_exceed_context_window(cmd_opts.max_context_length, messages)
+        max_tokens = get_max_tokens(cmd_opts.max_tokens, messages)
     end
 
     local request = {

--- a/lua/codegpt/utils.lua
+++ b/lua/codegpt/utils.lua
@@ -134,5 +134,21 @@ function Utils.remove_trailing_whitespace(lines)
     return lines
 end
 
+function Utils.fail_if_exceed_context_window(max_context_length, messages)
+    local ok, total_length = Utils.get_accurate_tokens(vim.fn.json_encode(messages))
+
+    if not ok then
+        for _, message in ipairs(messages) do
+            total_length = total_length + string.len(message.content)
+            total_length = total_length + string.len(message.role)
+        end
+    end
+
+    if total_length >= max_context_length then
+        error("Total length of messages exceeds max context length: " .. total_length .. " > " .. max_context_length)
+    end
+
+end
+
 
 return Utils


### PR DESCRIPTION
add config option 'max_output_tokens' so we can put 128k tokens in the input while setting the output token to some other value.

for example: gpt-4o input token limit is 128k, while output token limit is 4096